### PR TITLE
Make event generator parser of JSON files, add event functionality, add events

### DIFF
--- a/app.py
+++ b/app.py
@@ -92,7 +92,9 @@ def generate_realm(form):
         'nicknames': [],
         'names_noble': [],
         'names_male': [],
-        'names_female': []
+        'names_female': [],
+        'event_defs' : [],
+        'event_ids' : []
     }
 
     jsonfiles = glob.glob("realm_generator/word/*.json")
@@ -143,6 +145,10 @@ def generate_realm(form):
                     data['faction_suffixes'].extend(d['list'])
                 elif d['type'] == 'nicknames':
                     data['nicknames'].extend(d['list'])
+                elif d['type'] == 'event':
+                    if d['id'] not in data['event_ids']:
+                        data['event_defs'].append(d)
+                        data['event_ids'].append(d['id'])
 
     data['races'] = list(set(data['races']))
     data['animals'] = list(set(data['animals']))
@@ -177,7 +183,7 @@ def generate_realm(form):
         nobility
     )
 
-    event_generator = event.EventGenerator(nobility, factions)
+    event_generator = event.EventGenerator(data, nobility, factions)
     for _ in range(start_noble_events):
         event_generator.new_noble_event(data)
     for _ in range(start_courtier_events):

--- a/app.py
+++ b/app.py
@@ -117,6 +117,10 @@ def generate_realm(form):
                     data['names_male'].extend(d['list'])
                 elif d['type'] == 'names_female' and d['id'] in form.names_f.data:
                     data['names_female'].extend(d['list'])
+                elif d['type'] == 'event' and d['group_name'] in form.events.data:
+                    if d['id'] not in data['event_ids']:
+                        data['event_defs'].append(d)
+                        data['event_ids'].append(d['id'])
                 elif d['type'] == 'animals':
                     data['animals'].extend(d['list'])
                 elif d['type'] == 'appointments':
@@ -145,10 +149,6 @@ def generate_realm(form):
                     data['faction_suffixes'].extend(d['list'])
                 elif d['type'] == 'nicknames':
                     data['nicknames'].extend(d['list'])
-                elif d['type'] == 'event':
-                    if d['id'] not in data['event_ids']:
-                        data['event_defs'].append(d)
-                        data['event_ids'].append(d['id'])
 
     data['races'] = list(set(data['races']))
     data['animals'] = list(set(data['animals']))
@@ -216,6 +216,7 @@ class GenerateForm(flask_wtf.FlaskForm):
     names_n_data = []
     names_m_data = []
     names_f_data = []
+    event_data = []
     jsonfiles = glob.glob("realm_generator/word/*.json")
 
     for f in jsonfiles:
@@ -246,6 +247,8 @@ class GenerateForm(flask_wtf.FlaskForm):
                 names_m_data.append(d)
             elif d['type'] == 'names_female':
                 names_f_data.append(d)
+            elif d['type'] == "event" and d['group_name'] not in event_data:
+                event_data.append(d['group_name'])
 
     race_choices = []
     race_choices.extend([(s['id'], s['name']) for s in race_data])
@@ -274,6 +277,10 @@ class GenerateForm(flask_wtf.FlaskForm):
     names_f_choices = []
     names_f_choices.extend([(s['id'], s['name']) for s in names_f_data])
     names_f_choices.sort(key=lambda r: r[1])
+
+    event_choices = []
+    event_choices.extend([(name, name) for name in event_data])
+    event_choices.sort()
 
     great_families = wtforms.IntegerField(
         'Great Noble Families',
@@ -365,6 +372,13 @@ class GenerateForm(flask_wtf.FlaskForm):
         choices=names_f_choices,
         validators=[wtforms.validators.DataRequired()],
         default=[c[0] for c in names_f_choices if c[0][:4] == 'base']
+    )
+
+    events = MultiCheckboxField(
+        'Events',
+        choices=event_choices,
+        validators=[wtforms.validators.DataRequired()],
+        default=['Default']
     )
 
     submit = wtforms.SubmitField('Generate A Realm Now!')

--- a/app.py
+++ b/app.py
@@ -217,7 +217,7 @@ class GenerateForm(flask_wtf.FlaskForm):
     names_m_data = []
     names_f_data = []
     event_data = []
-    jsonfiles = glob.glob("realm_generator/word/*.json")
+    jsonfiles = glob.glob('realm_generator/word/*.json')
 
     for f in jsonfiles:
         with open(f, 'rb') as jfile:

--- a/event-definitions.md
+++ b/event-definitions.md
@@ -1,0 +1,502 @@
+# Event Definitions 
+
+Event definitions are a little complex, and reading the JSON schema is not very straightforward, so here is an explanation with some more detail as to how everything is meant to work.
+
+## Event Definition Basics
+
+Events are defined in JSON and parsed by the event generator. Below is an example of the simplest event possible:
+
+    {
+        "type" : "event",
+        "group_name" : "Default",
+        "event_type" : "noble",
+        "id" : "murdered_commoner",
+        "weight" : 1000,
+        "actor_defs" : [
+            {
+                "type" : "noble",
+                "var" : "n1"
+            }
+        ],
+        "attach_event" : [ "n1" ],
+        "description" : "|n1| was strongly suspected of the murder of a commoner"
+    }
+
+This contains every necessary property of an event, and everything in this event definition is required. We'll break it down by property:
+
+`"type" : "event"`
+* This is required by every event definition and should always be the same.
+
+`"group_name" : "Default"`
+* This is the name which will show up on the main page to allow the user to select groups of events to use. It must exactly match the group you want it to be in, but can be any string.
+
+`"event_type" : "noble"`
+* This determines what type of event it is generated as. The three allowed values are `"noble"`, `"courtier"`, and `"family"`.
+
+`"id" : "murdered_commoner"`
+* This is the event ID. It must be unique, as only one event definition with any given id will be loaded, in order to prevent accidental duplicates from altering the probabilities of events occurring.
+
+`"weight" : 1000`
+* This determines the frequency at which the event will be randomly selected. The base weight I have used is 1000, so any event that you want to occur at the normal rate should have weight 1000. If you want the event to occur less frequently, give it a lower weight. This can be used to, as in the marriage events, adjust specific properties' frequency of occurence, by creating two similar events with different actor requirements and then setting their combined weights to equal 1000. Every 1 weight then becomes 0.1% likelihood for the event going either way. See the "marriage_straight" and "marriage_gay" for an example of generating a lower-probability event based on requirements, in that case equal or unequal "sex" properties.
+
+`"actor_defs" : [
+    {
+        "type" : "noble",
+        "var" : "n1"
+    }
+],`
+* This is an array of what I've called "actors", which are nobles, courtiers, or families that are selected based on constraints (which I have called "requirements") and are then inserted into the description string to make the event. This is the simplest possible actor definition - one actor, with a type and variable. The possible types are `"noble"`, `"courtier"`, and `"family"`, corresponding to those same objects in the realm generator. The `"var"` is the string which will be replaced in the description and may be any unique string, with the following exceptions: `"faction"`, `"animal"`, `"adjective"`, or any other actor var or random token. Random tokens will be discussed below.
+
+`"attach_event" : [ "n1" ]`
+* This lists the actor variables representing the objects to which the event should be attached - any variable listed here will have the event appended to the corresponding object's events list. There must be at least one valid entry in the list or the event visible after the realm is generated.
+
+`"description" : "|n1| was strongly suspected of the murder of a commoner"`
+* This is the event text, with variables bracketed by the | character. Anything bracketed by the | character becomes a token, and if an actor variable exists with a matching string, that token will be replaced by the actor's name. There are a few special tokens: 
+    * `"noble"` and `"courtier"` type actors can have a `"family_var"` variable set, which will correspond to the name of the family they are members of
+    * `"courtier"` type actors can have a `"position_var"` variable, which will correspond to their position
+    * `|faction|` will be replaced by a randomly selected faction
+    * `|animal|` will be replaced by a randomly selected animal
+    * `|adjective|` will be replaced by a randomly selected adjective
+    * random tokens can be defined, which will replace the token with a random selection from a list provided in the event definition.
+    If the token is not found in the actor variables or random tokens, then the `|` characters will be stripped and the token will be put back into the description as it appears; if there was no `"n1"` actor variable available for this description to use, the description would literally read *"n1 was strongly suspected of the murder of a commoner"*.
+
+Very similarly to the above example, here are examples of two of the most basic family and courtier events:
+
+    {
+        "type" : "event",
+        "group_name" : "Default",
+        "event_type" : "family",
+        "id" : "uprising",
+        "weight" : 1000,
+        "actor_defs" : [
+            { "type" : "family", "var" : "f1" }
+        ],
+        "attach_event" : [ "f1" ],
+        "description" : "An uprising of smallfolk has taken hold against the |f1|"
+    }
+
+    {
+        "type" : "event",
+        "group_name" : "Default",
+        "event_type" : "courtier",
+        "id" : "duel",
+        "weight" : 1000,
+        "actor_defs" : [
+            { "type" : "courtier", "var" : "c1", "position_var": "c1p" },
+            { "type" : "noble", "var" : "n2", "family_var" : "f2" }
+        ],
+        "attach_event" : [ "c1", "n2" ],
+        "description" : "|c1| (|c1p|) was killed by |n2| of the |f2| in a duel of honour"
+    }
+
+The simple family event is pretty much the same as the previous example of a noble event, but you can see that the courtier event has two actors defined, each with an additional variable - the noble has its `family_var`, and the courtier has its `position_var`.
+
+Families are special, in that they can have actor definitions inside of them, in an array called `"member_defs"`, as seen in the example below:
+
+    {
+        "type" : "event",
+        "group_name" : "Default",
+        "event_type" : "courtier",
+        "id" : "hung",
+        "weight" : 1000,
+        "actor_defs" : [
+            { 
+                "type" : "family", "var" : "f1", "member_defs" : [
+                    { "type" : "courtier", "var" : "c1", "position_var": "c1p" },
+                    { "type" : "noble", "var" : "n1" }
+                ]
+            }
+        ],
+        "attach_event" : [ "c1", "n1" ],
+        "description" : "|c1| (|c1p|) was executed by |n1|"
+    }
+
+The contents of the `"member_defs"` array of a family works just like regular `"actor_defs"`, except that when the actors are generated they are guaranteed to be selected from the family's nobles and courtiers, instead of randomly from the entire population.
+
+## Actor Requirements 
+
+Actors of any kind can also have requirements attached to them, a simple case is shown below:
+
+    {
+        "type" : "event",
+        "group_name" : "Default",
+        "event_type" : "noble",
+        "id" : "baby",
+        "weight" : 1000,
+        "actor_defs" : [
+            {
+                "type" : "noble",
+                "req_gt" : { "age" : 18 },
+                "var" : "parent"
+            }
+        ],
+        "attach_event" : [ "parent" ],
+        "description" : "A baby was born to |parent|"
+    }
+
+There are a couple of things to note here. First, you can see that the actor's `"var"` is indeed a freeform string, it has been labelled `"parent"` here. As noted above, with a small handful of exceptions you can use any variable name you want to. The other thing to note is that this actor has a requirement - specifically, it includes the property `"req_gt" : { "age" : 18 }`. There are several requirements that can be used, listed below. This one means that only nobles with the property `"age"` greater than 18 can be selected for this event. If there was another property you wanted to make sure the actor was larger than (say, if a "height" property existed), you could add that to this same object, like `"req_gt" : { "age" : 18, "height" : 60 }`. You can not have more than one of any requirement property inside of the same actor (e.g. you can't have two "req_gt" properties on the same actor), you must include all the things you want to perform the same check on in the one property (in this case all "attribute greater than" requirements).
+
+The individual actor requirements that you can use are below:
+### Individual Actor Requirements
+* `"req_eq"`
+    * Require that an actor's attributes exactly match the properties given. The actor may have additional properties that are not listed, but if they do not have all of the properties listed matching exactly, they will not be selected.
+    * Example: `"req_eq" : { "sex" : "female" }`
+        * Actor will be female.
+* `"req_not_eq"`
+    * Require that an actor's attributes do not match the properties given. The actor may have additional properties that are not listed, but if any of their properties match the requirement, they will not be selected.
+    * Example: `"req_not_eq" : { "sex" : "female" }`
+        * Actor will not be female.
+* `"req_gt"`
+    * Require that an actor's attributes are greater than the properties given. This will perform a Python > between the given value and the attribute, so will work for e.g. lexographically ordered string comparisons as well as numbers.
+    * Example: `"req_gt" : { "age" : 18 }`
+        * Actor will have an age greater than 18
+* `"req_lt"`
+    * Require that an actor's attributes are less than the properties given. This will perform a Python < between the given value and the attribute, so will work for e.g. lexographically ordered string comparisons as well as numbers.
+    * Example: `"req_lt" : { "age" : 18 }`
+        * Actor will have an age less than 18
+* `"req_in"`
+    * This requires each property given to have an array of values, which the actor's attribute will be checked against to ensure that the actor's attribute is contained in the list provided by the definition.
+    * Example: `"req_in" : { "race" : [ "Tortle", "Lizardfolk", "Triton" ] }`
+        * Actor will have the race "Tortle", "Lizardfolk", or "Triton"
+* `"req_not_in"`
+    * This requires each property given to have an array of values, which the actor's attribute will be checked against to ensure that the actor's attribute is not contained in the list provided by the definition.
+    * Example: `"req_not_in" : { "race" : [ "Tortle", "Lizardfolk", "Triton" ] }`
+        * Actor will not have the race "Tortle", "Lizardfolk", or "Triton"
+* `"req_has"`
+    * Require that the actor has the given attributes and that they have values (i.e. are not `None`).
+    * Example: `"req_has" : [ "post_nickname" ]`
+        * Actor will have a post_nickname
+* `"req_not_has"`
+    * Require that the actor does not have the given attributes or that if they do the attributes do not have values (i.e. are `None`)
+    * Example: `"req_not_has" : [ "post_nickname" ]`
+        Actor will not have a post_nickname
+* `"req_len_gt"` 
+    * Require that the actor's attribute has a number of items greater than the number given. This is primarily of concern when defining family events to ensure that the family has enough courtiers, persons, vassals, etc. It could also be used to limit the number of events assigned to an actor.
+    * Example: `"req_len_gt" : { "courtiers" : 1, "persons" : 0 }`
+        * Actor will have at least two courtiers and at least one persons
+* `"req_len_lt"`
+    Require that the actor's attribute has a number of items less than the number given.
+    * Example: `"req_len_lt" : { "knights" : 1, "vassals" : 1 }`
+        * Actor will have fewer than 1 knights and fewer than 1 vassals.
+
+See below for an example of an event with most of the requirements on a single actor, which was used while testing:
+
+    {
+        "type" : "event",
+        "group_name" : "Test",
+        "id" : "very_specific_contest",
+        "weight" : 1000,
+        "event_type" : "noble",
+        "actor_defs" : [
+            {
+                "type" : "noble", "var" : "n1", "family_var" : "f1",
+                "req_eq" : { "sex" : "female" },
+                "req_not_eq" : { "leader_relation" : "wife" },
+                "req_gt" : { "age" : 20 },
+                "req_lt" : { "age" : 30 },
+                "req_in" : { "race" : [ "Tortle", "Lizardfolk", "Triton" ] },
+                "req_not_in" : { "alignment_print" : [ "Lawful Evil", "Neutral Evil", "Chaotic Evil" ] },
+                "req_has" : [ "post_nickname" ],
+                "req_not_has" : [ "pre_nickname" ]
+            }
+        ],
+        "attach_event" : [ "n1" ],
+        "description" : "|n1| won a contest with suspiciously specific requirements"
+    }
+
+This defines an actor who is: a noble; female; not the family leader's wife; between the ages of 20 and 30; a Tortle, Lizardfok, or Triton; not Evil aligned; and has a nickname after her name, but not before it. Seems like a setup to me.
+
+## Required Matches 
+
+In addition to individual actor requirements, you can also define requirements that take into account multiple actors. See the below event definition:
+
+    {
+        "type" : "event",
+        "group_name" : "Default",
+        "event_type" : "courtier",
+        "id" : "office_swap",
+        "weight" : 1000,
+        "actor_defs" : [
+            {
+                "type" : "family", "var" : "f1",
+                "req_len_gt" : { "courtiers" : 1, "persons" : 0 },
+                "member_defs" : [
+                    { "type" : "courtier", "var" : "c1", "position_var" : "c1p" },
+                    { "type" : "courtier", "var" : "c2", "position_var" : "c2p" },
+                    { "type" : "noble", "var" : "n1" }
+                ]
+            }
+        ],
+        "req_matches" : [
+            {
+                "actors" : [ "c1", "c2" ],
+                "req_actors_any_neq" : [ "pre_nickname", "firstname", "post_nickname" ]
+            }
+        ],
+        "attach_event" : [ "c1", "c2" ],
+        "description" : "|c1| (|c1p|) and |c2| (|c2p|) have swapped offices by order of |n1| of |f1|"
+    }
+
+There's a lot there, but we've already been through what most of it means. This is a normal weight courtier event named office_swap, and it defines four actors: a family with at least 2 courtiers and 1 noble, and then two courtiers and a noble who are members of that family. You can also see that the courtiers' positions are taken as variables `"c1p"` and `"c2p"` and used in the description string, along with the noble and family name. The event is attached to both of the courtiers, but not to the noble.
+
+Below the actor_defs, you can see a new event defintion property that we have not discussed before: `"req_matches"`. This is an array of objects, in which each object defines a group of actors and what must or must not match between them. In this case, it applies the requirement to the actors `"c1"` and `"c2"`, and requires that any one of their `"pre_nickname"`, `"firstname"`, or `"post_nickname"` must not match. The word "any" is important there; if two of the three things match but the third one doesn't, then that will still be an OK selection. This particular requirement is to ensure that the same actor is not picked - if any of those three attributes are different, then it's a different person. The same requirement with `"family_name"` added is used to ensure that two nobles are different people in some events.
+
+Note that if desired, the noble and either courtier (or the noble and both courtiers) could be added in separate object in the `"req_matches"` array, to apply different match requirements to those groups. You may have as many groups as you want in the `"req_matches"` array, but if it is present you must have at least one. The `"actors"` array requires at least two items or it will be ignored, because it doesn't make sense to check that something is or is not equal to itself.
+
+There are several matching requirements that can be used:
+### Match Requirements
+* `"req_actors_any_eq"`
+    * Requires that all of the actors have any of the listed attributes matching.
+    * Example: `"req_actors_any_eq" : [ "sex", "alignment" ]`
+        * This will match if all of the actors have matching sex or alignment (or both)
+* `"req_actors_any_neq"`
+    * Requires that all of the actors have any of the listed attributes not matching.
+    * Example: `"req_actors_any_neq" : [ "pre_nickname", "firstname", "post_nickname", "family_name" ]`
+        * This will match if all of the actors have any part of their name that isn't the same. It is used frequently to guarantee unique actors in events with two actors.
+* `"req_actors_all_eq"`
+    * Requires that all of the actors have all of the listed attributes matching.
+    * Example: `"req_actors_all_eq" : [ "sex" ]`
+        * This will match if the actors are all the same sex.
+* `"req_actors_all_neq"`
+    * Requires that all of the actors have all of the listed attributes not matching.
+    * Example: `"req_actors_all_neq" : [ "sex" ]`
+        * This will match if none of the actors are the same sex. Unless you have modified the realm generator software (which at this time only contains two sexes), this will only work for two actors at a time.
+* `"req_vassalage"`
+    * Requires that one of the actors is a vassal of the other. This is different from the other match requirements, in that it only applies to two actors at a time and is formatted as an object with properties "lord" and "vassal".
+    * Example: `"req_vassalage" : { "lord" : "f1", "vassal" : "f2" }`
+        * This will match if `"f2"` is a vassal (knight or vassal) of `"f1"`
+
+## Random Tokens
+
+As was previously stated, descriptions can include several different types of tokens: actor variables; the special tokens `|faction|`, `|animal|`, and `|adjective|`; and random tokens. Random tokens are defined in the event definition with a list of replacements which get chosen from when the event is generated. See an example below:
+
+    {
+        "type" : "event",
+        "group_name" : "Signs & Omens",
+        "event_type" : "noble",
+        "id" : "strange-colored-fire",
+        "weight" : 100,
+        "actor_defs" : [
+            { "type" : "noble", "var" : "n", "family_var" : "f" }
+        ],
+        "attach_event" : [ "n" ],
+        "random_tokens" : { "color" : [ "blue", "green", "purple", "white", "pink" ] },
+        "description" : "A fire was seen turning |color| when |n| approached"
+    }
+
+You can see that it has a `"random_tokens"` property, which is an object named `"color"` and an array of colors. The description then contains the token `|color|`. When the event is generated, a color will be selected at random from the list and used in place of the `|color|` token. This is a `random.choice()` selection, so it will be equally weighted; if you want to weight your choices, then the only current method of doing so is to add more entries in proportion to the desired weights. If I had put `"blue"` in four times, it would have a 50% chance of being chosen, but since I did not it will be chosen 20% of the time.
+
+The random tokens are processed and replaced before the other variables, which lets you replace a random token with an actor variable (or special token). See the below example:
+
+    {
+        "type" : "event",
+        "group_name" : "Default",
+        "event_type" : "noble",
+        "id" : "honour_duel",
+        "weight" : 1000,
+        "actor_defs" : [
+            {
+                "type" : "noble",
+                "req_gt" : { "age" : 17 },
+                "var" : "n1",
+                "family_var" : "f1"
+            },
+            {
+                "type" : "noble",
+                "req_gt" : { "age" : 17 },
+                "var" : "n2",
+                "family_var" : "f2"
+            }
+        ],
+        "req_matches" : [
+            {
+                "actors" : [ "n1", "n2" ],
+                "req_actors_any_neq" : [ 
+                    "pre_nickname", 
+                    "firstname", 
+                    "post_nickname", 
+                    "family_name" 
+                ]
+            }
+        ],
+        "attach_event" : [ "n1", "n2" ],
+        "random_tokens" : { "winner" : [ "n1", "n2" ] },
+        "description" : "|n1| of the |f1| dueled with |n2| of the |f2|; |winner| won"
+    }
+
+This is quite long, and shows off many of the things we have discussed so far. The part that is most interesting at this point is at the bottom. You can see that the random_tokens defines a token named `"winner"` that can be `"n1"` or `"n2"`, which are the same as the two actor variables. When the event is being generated, the random tokens will be processed first, so `|winner|` will get replaced with either `n1` or `n2`. Then, when the actor variables are processed, that token will be treated as if it was always the actor variable, so we can have a random winner of the duel. Note that when used in this way the random token list should not include the `|` characters - those are stripped in an earlier step, and will result in the description including them literally as `"|n1|"` or `"|n2|"`.
+
+There is an alternate method of acheiving this same behavior: create two events that are the same, but with different ids and a different actor token in the description, and then give them each half of the weight. 
+
+## More Examples 
+
+Reading over the existing event definitions in the `"base-events.json"` and `"events-omens.json"` files in the words directory should give you a good understanding of what the various features are being used for, but every feature of the event definition system is not represented in them. Below are some events that I used during testing, which show off some of the features and ways to do things. Note that these are also not exhaustive, and I'm sure that there are clever or interesting ways to use the various features that I have not discovered myself. For testing new events, I have found that it is easiest to turn off all non-test events and generate a realm with 1 Great, 1 Minor, and 1 Petty house; this guarantees you will get very long lists on each house page containing many of your test events.
+
+    {
+        "type" : "event",
+        "group_name" : "Test",
+        "id" : "tournament_sexism",
+        "weight" : 1000,
+        "event_type" : "noble",
+        "actor_defs" : [
+            {
+                "type" : "noble",
+                "req_eq" : { "sex" : "female" },
+                "var" : "n1",
+                "family_var" : "f1"
+            }
+        ],
+        "attach_event" : [ "n1" ],
+        "description" : "|n1| was caught trying to compete in a tournament as a man"
+    },
+    {
+        "type" : "event",
+        "group_name" : "Test",
+        "id" : "impotence_rumors",
+        "weight" : 1000,
+        "event_type" : "noble",
+        "actor_defs" : [
+            {
+                "type" : "noble",
+                "req_not_eq" : { "sex" : "female" },
+                "var" : "n1",
+                "family_var" : "f1"
+            }
+        ],
+        "attach_event" : [ "n1" ],
+        "description" : "Rumors have spread that |n1| is impotent"
+    },
+    {
+        "type" : "event",
+        "group_name" : "Test",
+        "id" : "drow_are_too_edgy",
+        "weight" : 1000,
+        "event_type" : "noble",
+        "actor_defs" : [
+            {
+                "type" : "noble",
+                "req_eq" : {  "race" : "Elf (Drow)" },
+                "var" : "n1",
+                "family_var" : "f1"
+            }
+        ],
+        "attach_event" : [ "n1" ],
+        "description" : "|n1| died of bloodloss after getting cut on all their edginess"
+    },
+    {
+        "type" : "event",
+        "group_name" : "Test",
+        "id" : "racism_against_dwarves",
+        "weight" : 1000,
+        "event_type" : "noble",
+        "actor_defs" : [
+            {
+                "type" : "noble",
+                "req_not_in" : { 
+                    "race" : [
+                        "Dwarf (Duergar)",
+                        "Dwarf (Hill)",
+                        "Dwarf (Mark of Warding)",
+                        "Dwarf (Mountain)" ]
+                },
+                "var" : "n1",
+                "family_var" : "f1"
+            }
+        ],
+        "attach_event" : [ "n1" ],
+        "description" : "|n1| was heard loudly proclaiming all Dwarves to be greedy thieves"
+    },
+    {
+        "type" : "event",
+        "group_name" : "Test",
+        "id" : "marie_antoinette",
+        "weight" : 1000,
+        "event_type" : "noble",
+        "actor_defs" : [
+            {
+                "type" : "noble",
+                "req_not_in" : { 
+                    "rank" : [ "petty", "minor", "great" ]
+                },
+                "var" : "n1",
+                "family_var" : "f1"
+            }
+        ],
+        "attach_event" : [ "n1" ],
+        "description" : "|n1| was overheard asking why starving peasants didn't just eat brioche"
+    },
+    {
+        "type" : "event",
+        "group_name" : "Test",
+        "id" : "jealous_nicknames",
+        "weight" : 1000,
+        "event_type" : "noble",
+        "actor_defs" : [
+            {
+                "type" : "noble",
+                "req_not_has" : [ "pre_nickname", "post_nickname" ],
+                "var" : "jelly"
+            }
+        ],
+        "attach_event" : [ "jelly" ],
+        "description" : "|jelly| made a failed attempt to ban the use of nicknames"
+    },
+    {
+        "type" : "event",
+        "group_name" : "Test",
+        "id" : "feud_start",
+        "weight" : 1000,
+        "event_type" : "noble",
+        "actor_defs" : [
+            { "type" : "noble", "var" : "n1", "family_var" : "f1" },
+            { "type" : "noble", "var" : "n2", "family_var" : "f2" }
+        ],
+        "req_matches" : [
+            {
+                "actors" : [ "n1", "n2" ],
+                "req_actors_any_eq" : [ "sex" ]
+            },
+            {
+                "actors" : [ "f1", "f2" ],
+                "req_actors_all_neq" : [ "name" ]
+            }
+        ],
+        "attach_event" : [ "f1", "f2" ],
+        "description" : "|f1| and |f2| started feuding over a dispute between |n1| and |n2|"
+    },
+    {
+        "type" : "event",
+        "group_name" : "Test",
+        "event_type" : "courtier",
+        "id" : "petty_fistfight",
+        "weight" : 1000,
+        "actor_defs" : [
+            { 
+                "type" : "family", "var" : "f1",
+                "member_defs" : [
+                    { "type" : "courtier", "var" : "c1", "position_var" : "c1p" },
+                    { "type" : "courtier", "var" : "c2", "position_var" : "c2p" }
+                ]
+            }
+        ],
+        "req_matches" : [
+            {
+                "actors" : [ "c1", "c2" ],
+                "req_actors_any_neq" : [ "pre_nickname", "firstname", "post_nickname" ]
+            }
+        ],
+        "attach_event" : [ "c1", "c2" ],
+        "description" : "|c1| got into a fistfight with |c2| after |c2| called |c1p| a pointless job"
+    },
+    {
+        "type" : "event",
+        "group_name" : "Test",
+        "event_type" : "family",
+        "id" : "family_gone_crazy",
+        "weight" : 1000,
+        "actor_defs" : [
+            { "type" : "family", "var" : "f" }
+        ],
+        "attach_event" : [ "f" ],
+        "description" : "The |f| has dissolved after donating all of their land to |faction| and leaving to follow a |animal|. They were heard calling the rest of the nobility |adjective| on their way off."
+    }

--- a/event-definitions.md
+++ b/event-definitions.md
@@ -335,7 +335,7 @@ The random tokens are processed and replaced before the other variables, which l
 
 This is quite long, and shows off many of the things we have discussed so far. The part that is most interesting at this point is at the bottom. You can see that the random_tokens defines a token named `"winner"` that can be `"n1"` or `"n2"`, which are the same as the two actor variables. When the event is being generated, the random tokens will be processed first, so `|winner|` will get replaced with either `n1` or `n2`. Then, when the actor variables are processed, that token will be treated as if it was always the actor variable, so we can have a random winner of the duel. Note that when used in this way the random token list should not include the `|` characters - those are stripped in an earlier step, and will result in the description including them literally as `"|n1|"` or `"|n2|"`.
 
-There is an alternate method of acheiving this same behavior: create two events that are the same, but with different ids and a different actor token in the description, and then give them each half of the weight. 
+There is an alternate method of achieving this same behavior: create two events that are the same, but with different ids and a different actor token in the description, and then give them each half of the weight. 
 
 ## More Examples 
 

--- a/event-definitions.md
+++ b/event-definitions.md
@@ -37,7 +37,7 @@ This contains every necessary property of an event, and everything in this event
 * This is the event ID. It must be unique, as only one event definition with any given id will be loaded, in order to prevent accidental duplicates from altering the probabilities of events occurring.
 
 `"weight" : 1000`
-* This determines the frequency at which the event will be randomly selected. The base weight I have used is 1000, so any event that you want to occur at the normal rate should have weight 1000. If you want the event to occur less frequently, give it a lower weight. This can be used to, as in the marriage events, adjust specific properties' frequency of occurence, by creating two similar events with different actor requirements and then setting their combined weights to equal 1000. Every 1 weight then becomes 0.1% likelihood for the event going either way. See the "marriage_straight" and "marriage_gay" for an example of generating a lower-probability event based on requirements, in that case equal or unequal "sex" properties.
+* This determines the frequency at which the event will be randomly selected. The base weight I have used is 1000, so any event that you want to occur at the normal rate should have weight 1000. If you want the event to occur less frequently, give it a lower weight. This can be used to, as in the marriage events, adjust specific properties' frequency of occurence, by creating two similar events with different actor requirements and then setting their combined weights to equal 1000. Every 1 weight then becomes 0.1% likelihood for the event going either way. See the "marriage_straight" and "marriage_gay" event definitions in `base-events.json` for an example of generating a lower-probability event based on requirements, in that case equal or unequal "sex" properties.
 
 `"actor_defs" : [
     {
@@ -45,15 +45,24 @@ This contains every necessary property of an event, and everything in this event
         "var" : "n1"
     }
 ],`
-* This is an array of what I've called "actors", which are nobles, courtiers, or families that are selected based on constraints (which I have called "requirements") and are then inserted into the description string to make the event. This is the simplest possible actor definition - one actor, with a type and variable. The possible types are `"noble"`, `"courtier"`, and `"family"`, corresponding to those same objects in the realm generator. The `"var"` is the string which will be replaced in the description and may be any unique string, with the following exceptions: `"faction"`, `"animal"`, `"adjective"`, or any other actor var or random token. Random tokens will be discussed below.
+* This is an array defining what I've called "actors", which are nobles, courtiers, or families that are selected based on constraints (which I have called "requirements") and are then inserted into the description string to make the event. This is the simplest possible actor definition - one actor, with a type and variable.
+    * Every actor definition is *required* to have the following properties:
+        * `"type"`: may be `"noble"`, `"courtier"`, or `"family'`, corresponding to the objects of the same names in the realm generator
+        * `"var"`: is used as a token in the `"description"`, where it will be replaced with the actor's name; may be any string except the following:
+            * `"faction"`
+            * `"animal"`
+            * `"adjective"`
+            * any other defined actor variable 
+            * any defined random token (discussed further in their own section)
+    * Noble and Courtier actors may have additional optional variables defined:
+        * `"noble"` and `"courtier"` type actors may have a `"family_var"` variable set, which will be replaced with the name of the family they are members of; this has the same restrictions as the actor's `"var"`
+        * `"courtier"` type actors may have a `"position_var"` variable, which will be replaced with their position; this has the same restrictions as the actor's `"var"`
 
 `"attach_event" : [ "n1" ]`
 * This lists the actor variables representing the objects to which the event should be attached - any variable listed here will have the event appended to the corresponding object's events list. There must be at least one valid entry in the list or the event visible after the realm is generated.
 
 `"description" : "|n1| was strongly suspected of the murder of a commoner"`
-* This is the event text, with variables bracketed by the | character. Anything bracketed by the | character becomes a token, and if an actor variable exists with a matching string, that token will be replaced by the actor's name. There are a few special tokens: 
-    * `"noble"` and `"courtier"` type actors can have a `"family_var"` variable set, which will correspond to the name of the family they are members of
-    * `"courtier"` type actors can have a `"position_var"` variable, which will correspond to their position
+* This is the event description text, with tokens bracketed by the `|` character. Anything bracketed by the `|` character becomes a token, and if an actor variable exists with a matching string, that token will be replaced by the actor's name. There are a few special tokens: 
     * `|faction|` will be replaced by a randomly selected faction
     * `|animal|` will be replaced by a randomly selected animal
     * `|adjective|` will be replaced by a randomly selected adjective

--- a/realm_generator/event.py
+++ b/realm_generator/event.py
@@ -6,9 +6,26 @@ from realm_generator import person
 
 
 class EventGenerator():
-    def __init__(self, nobility, factions):
+    def __init__(self, data, nobility, factions):
         self.nobility = nobility
         self.factions = factions
+        self.noble_event_defs = []
+        self.noble_event_weights = []
+        self.courtier_event_defs = []
+        self.courtier_event_weights = []
+        self.family_event_defs = []
+        self.family_event_weights = []
+
+        for e_def in data['event_defs']:
+            if e_def['event_type'] == 'noble':
+                self.noble_event_defs.append(e_def)
+                self.noble_event_weights.append(e_def['weight'])
+            elif e_def['event_type'] == 'courtier':
+                self.courtier_event_defs.append(e_def)
+                self.courtier_event_weights.append(e_def['weight'])
+            elif e_def['event_type'] == 'family':
+                self.family_event_defs.append(e_def)
+                self.family_event_weights.append(e_def['weight'])
 
     def new_noble_event(self, data):
         event_fs = inspect.getmembers(

--- a/realm_generator/event.py
+++ b/realm_generator/event.py
@@ -77,6 +77,15 @@ class EventGenerator():
         if group_attempts == 0:
             return None
         # build description using defined description and actors
+        # first pass to replace random tokens
+        if 'random_tokens' in event_def.keys():
+            converted = []
+            for token in tokens:
+                if token in event_def['random_tokens'].keys():
+                    token = random.choice(event_def['random_tokens'][token])
+                converted.append(token)
+            tokens = converted
+        # build description by substituting actor names for tokens
         for token in tokens:
             if token in actors.keys():
                 if actors[token]['type'] == 'family':

--- a/realm_generator/event.py
+++ b/realm_generator/event.py
@@ -162,6 +162,8 @@ class EventGenerator():
         if actors == {} or 'req_matches' not in event_def.keys():
             return True
         for match in event_def['req_matches']:
+            if len(match['actors']) < 2:
+                break
             entities = [ v['object'] for k, v in actors.items() if k in match['actors']]
             if 'req_actors_any_eq' in match.keys():
                 suitable = False

--- a/realm_generator/event.py
+++ b/realm_generator/event.py
@@ -99,7 +99,7 @@ class EventGenerator():
             elif token == 'faction':
                 desc_list.append(random.choice(self.factions).name)
             elif token == 'animal':
-                desc_list.append(random.choice(data['animals']))
+                desc_list.append(random.choice(data['animals']).lower())
             elif token == 'adjective':
                 desc_list.append(random.choice(data['adjectives']))
             else:

--- a/realm_generator/event.py
+++ b/realm_generator/event.py
@@ -11,6 +11,9 @@ class EventGenerator():
     def __init__(self, data, nobility, factions):
         self.nobility = nobility
         self.factions = factions
+        self.all_families = family.all_families(nobility)
+        self.all_nobles = family.all_nobles(nobility)
+        self.all_courtiers = family.all_courtiers(nobility)
         self.noble_event_defs = []
         self.noble_event_weights = []
         self.courtier_event_defs = []
@@ -227,7 +230,7 @@ class EventGenerator():
         # get a family meeting requirements
         while not suitable and actor_attempts > 0:
             actor_attempts -= 1
-            f = family.random_family(self.nobility)
+            f = random.choice(self.all_families)
             suitable = self.is_suitable(f, actor_def)
         if actor_attempts == 0:
             return None
@@ -259,7 +262,7 @@ class EventGenerator():
                 f = fam
                 n = random.choice(f.persons)
             else:
-                f, n = random.choice(family.all_nobles(self.nobility))
+                f, n = random.choice(self.all_nobles)
             suitable = self.is_suitable(n, actor_def)
         if actor_attempts == 0:
             return None
@@ -279,7 +282,7 @@ class EventGenerator():
                 c = random.choice(fam.courtiers)
                 f = fam
             else:
-                c = random.choice(family.all_courtiers(self.nobility))
+                c = random.choice(self.all_courtiers)
             suitable = self.is_suitable(c, actor_def)
         if actor_attempts == 0:
             return None

--- a/realm_generator/event.py
+++ b/realm_generator/event.py
@@ -1,9 +1,11 @@
 import random
-import inspect
 
 from realm_generator import family
 from realm_generator import person
 
+
+MAX_ACTOR_ATTEMPTS = 1000
+MAX_GROUP_ATTEMPTS = 1000
 
 class EventGenerator():
     def __init__(self, data, nobility, factions):
@@ -28,651 +30,265 @@ class EventGenerator():
                 self.family_event_weights.append(e_def['weight'])
 
     def new_noble_event(self, data):
-        event_fs = inspect.getmembers(
-            self,
-            predicate=inspect.ismethod
-        )
-        fs_list = [y for (x, y) in event_fs if x.startswith("gen_event_n_")]
-        return self._new_event(data, fs_list)
+        event_def = random.choices(self.noble_event_defs, weights=self.noble_event_weights)
+        return self._new_event(data, event_def[0])
 
     def new_courtier_event(self, data):
-        event_fs = inspect.getmembers(
-            self,
-            predicate=inspect.ismethod
-        )
-        fs_list = [y for (x, y) in event_fs if x.startswith("gen_event_c_")]
-        return self._new_event(data, fs_list)
+        event_def = random.choices(self.courtier_event_defs, weights=self.courtier_event_weights)
+        return self._new_event(data, event_def[0])
 
     def new_family_event(self, data):
-        event_fs = inspect.getmembers(
-            self,
-            predicate=inspect.ismethod
-        )
-        fs_list = [y for (x, y) in event_fs if x.startswith("gen_event_f_")]
-        return self._new_event(data, fs_list)
+        event_def = random.choices(self.family_event_defs, weights=self.family_event_weights)
+        return self._new_event(data, event_def[0])
 
-    def _new_event(self, data, fs_list):
-        if len(fs_list) == 0:
-            return
-        event = random.choice(fs_list)(data)
-        for o in event.affected_organizations:
-            o.events.append(event)
-        del event.affected_organizations  # prevent circular reference
-        for p in event.affected_persons:
-            p.events.append(event)
-        del event.affected_persons  # prevent circular reference
+    def _new_event(self, data, event_def):
+        event = Event(data)
+        actors = {}
+        desc_list = []
+        tokens = event_def['description'].split('|')
+        group_attempts = MAX_GROUP_ATTEMPTS
+        matching = False
+        # get all actors defined in event definition
+        while not matching and group_attempts > 0:
+            group_attempts -= 1
+            for actor_def in event_def['actor_defs']:
+                if actor_def['type'] == 'family':
+                    family = self.get_family_for_event(actor_def)
+                    if family is None:
+                        return None
+                    else:
+                        actors.update(family)
+                elif actor_def['type'] == 'noble':
+                    noble = self.get_noble_for_event(actor_def)
+                    if noble is None:
+                        return None
+                    else:
+                        actors.update(noble)
+                elif actor_def['type'] == 'courtier':
+                    courtier = self.get_courtier_for_event(actor_def)
+                    if courtier is None:
+                        return None
+                    else:
+                        actors.update(courtier)
+            matching = self.match_reqs(actors, event_def)
+        if group_attempts == 0:
+            return None
+        # build description using defined description and actors
+        for token in tokens:
+            if token in actors.keys():
+                if actors[token]['type'] == 'family':
+                    desc_list.append(actors[token]['object'].create_html_a_name(self.nobility))
+                elif actors[token]['type'] == 'noble':
+                    desc_list.append(actors[token]['object'].get_full_title())
+                elif actors[token]['type'] == 'courtier':
+                    desc_list.append(actors[token]['object'].get_first_name())
+                elif actors[token]['type'] == 'c_position':
+                    desc_list.append(actors[token]['position'])
+            elif token == 'faction':
+                desc_list.append(random.choice(self.factions).name)
+            elif token == 'animal':
+                desc_list.append(random.choice(data['animals']))
+            elif token == 'adjective':
+                desc_list.append(random.choice(data['adjectives']))
+            else:
+                desc_list.append(token)
+        event.description = "".join(desc_list)
+        # attach event to appropriate persons/families
+        for var in event_def['attach_event']:
+            if (actors[var]['type'] == 'family'
+                    or actors[var]['type'] == 'noble' 
+                    or actors[var]['type'] == 'courtier'):
+                actors[var]['object'].events.append(event)
         return event
 
-    def gen_event_n_matrimony(self, data):
-        event = Event(data)
+    def is_suitable(self, entity, actor_def):
+        suitable = True
+        e_dict = vars(entity)
+        if 'req_eq' in actor_def.keys():
+            if not e_dict.items() >= actor_def['req_eq'].items():
+                suitable = False
+        if 'req_not_eq' in actor_def.keys():
+            if e_dict.items() >= actor_def['req_not_eq'].items():
+                suitable = False
+        if 'req_gt' in actor_def.keys():
+            for k, v in actor_def['req_gt'].items():
+                if k not in e_dict.keys() or e_dict[k] <= v:
+                    suitable = False
+        if 'req_lt' in actor_def.keys():
+            for k, v in actor_def['req_lt'].items():
+                if k not in e_dict.keys() or e_dict[k] >= v:
+                    suitable = False
+        if 'req_in' in actor_def.keys():
+            for k, v in actor_def['req_in'].items():
+                if k not in e_dict.keys() or e_dict[k] not in v:
+                    suitable = False
+        if 'req_not_in' in actor_def.keys():
+            for k, v in actor_def['req_not_in'].items():
+                if k in e_dict.keys() and e_dict[k] in v:
+                    suitable = False
+        if 'req_has' in actor_def.keys():
+            for k in actor_def['req_has']:
+                if k not in e_dict.keys() or e_dict[k] is None:
+                    suitable = False
+        if 'req_not_has' in actor_def.keys():
+            for k in actor_def['req_not_has']:
+                if k in e_dict.keys() and e_dict[k] is not None:
+                    suitable = False
+        if 'req_len_gt' in actor_def.keys():
+            for k, v in actor_def['req_len_gt'].items():
+                if k not in e_dict.keys() or len(e_dict[k]) <= v:
+                    suitable = False
+        if 'req_len_lt' in actor_def.keys():
+            for k, v in actor_def['req_len_lt'].items():
+                if k not in e_dict.keys() or len(e_dict[k]) >= v:
+                    suitable = False
+        return suitable
 
-        nobles = family.all_nobles(self.nobility)
-        f1, n1 = random.choice(nobles)
-        f2, n2 = random.choice(nobles)
+    def match_reqs(self, actors, event_def):
+        suitable = True
+        entities = []
+        if actors == {} or 'req_matches' not in event_def.keys():
+            return True
+        for match in event_def['req_matches']:
+            entities = [ v['object'] for k, v in actors.items() if k in match['actors']]
+            if 'req_actors_any_eq' in match.keys():
+                suitable = False
+                e = entities.pop()
+                e_dict = vars(e)
+                for attr in match['req_actors_any_eq']:
+                    for a in entities:
+                        a_dict = vars(a)
+                        if attr in a_dict.keys() and a_dict[attr] == e_dict[attr]:
+                            suitable = True
+                            break
+                entities.append(e)
+            if 'req_actors_any_neq' in match.keys():
+                suitable = False
+                e = entities.pop()
+                e_dict = vars(e)
+                for attr in match['req_actors_any_neq']:
+                    for a in entities:
+                        a_dict = vars(a)
+                        if attr in a_dict.keys() and a_dict[attr] != e_dict[attr]:
+                            suitable = True
+                            break
+                entities.append(e)
+            if 'req_actors_all_eq' in match.keys():
+                e = entities.pop()
+                e_dict = vars(e)
+                for attr in match['req_actors_all_eq']:
+                    for a in entities:
+                        a_dict = vars(a)
+                        if attr in a_dict.keys() and a_dict[attr] != e_dict[attr]:
+                            suitable = False
+                            break
+                entities.append(e)
+            if 'req_actors_all_neq' in match.keys():
+                e = entities.pop()
+                e_dict = vars(e)
+                for attr in match['req_actors_all_neq']:
+                    for a in entities:
+                        a_dict = vars(a)
+                        if attr in a_dict.keys() and a_dict[attr] == e_dict[attr] and e_dict[attr] is not None:
+                            suitable = False
+                            break
+                entities.append(e)
+            if 'req_vassalage' in match.keys():
+                v = actors[match['req_vassalage']['vassal']]['object']
+                l = actors[match['req_vassalage']['lord']]['object']
+                if v not in l.vassals and v not in l.knights:
+                    suitable = False
+        return suitable
 
-        if random.random() * 100 > 10:
-            while (n1.sex == n2.sex or
-                    n1.get_full_title() == n2.get_full_title()):
-                f2, n2 = random.choice(nobles)
-        else:
-            while n1.get_full_title() == n2.get_full_title():
-                f2, n2 = random.choice(nobles)
-
-        event.affected_persons.append(n1)
-        event.affected_persons.append(n2)
-        event.affected_organizations.append(f1)
-        event.affected_organizations.append(f2)
-
-        event.description = "{} of the {} was wed to {} of the {}".format(
-            n1.get_full_title(),
-            f1.create_html_a_name(self.nobility),
-            n2.get_full_title(),
-            f2.create_html_a_name(self.nobility)
-        )
-
-        return event
-
-    def gen_event_n_divorce(self, data):
-        event = Event(data)
-
-        nobles = family.all_nobles(self.nobility)
-        f1, n1 = random.choice(nobles)
-        f2, n2 = random.choice(nobles)
-
-        if random.random() * 100 > 3.5:
-            while (n1.sex == n2.sex or
-                    n1.get_full_title() == n2.get_full_title()):
-                f2, n2 = random.choice(nobles)
-        else:
-            while n1.get_full_title() == n2.get_full_title():
-                f2, n2 = random.choice(nobles)
-
-        event.affected_persons.append(n1)
-        event.affected_persons.append(n2)
-        event.affected_organizations.append(f1)
-        event.affected_organizations.append(f2)
-
-        event.description = (
-            "{} of the {} and {} of the {} officially divorced"
-        ).format(
-            n1.get_full_title(),
-            f1.create_html_a_name(self.nobility),
-            n2.get_full_title(),
-            f2.create_html_a_name(self.nobility)
-        )
-
-        return event
-
-    def gen_event_n_illicit_lovers(self, data):
-        event = Event(data)
-
-        nobles = family.all_nobles(self.nobility)
-        f1, n1 = random.choice(nobles)
-        f2, n2 = random.choice(nobles)
-
-        if random.random() * 100 > 3.5:
-            while (n1.sex == n2.sex or
-                    n1.get_full_title() == n2.get_full_title()):
-                f2, n2 = random.choice(nobles)
-        else:
-            while n1.get_full_title() == n2.get_full_title():
-                f2, n2 = random.choice(nobles)
-
-        event.affected_persons.append(n1)
-        event.affected_persons.append(n2)
-        event.affected_organizations.append(f1)
-        event.affected_organizations.append(f2)
-
-        event.description = (
-            "An illicit love affair was discovered "
-            "between {} of the {} and {} of the {}".format(
-                n1.get_full_title(),
-                f1.create_html_a_name(self.nobility),
-                n2.get_full_title(),
-                f2.create_html_a_name(self.nobility)
-            )
-        )
-
-        return event
-
-    def gen_event_n_baby(self, data):
-        event = Event(data)
-        _, n = family.random_noble(self.nobility)
-        event.affected_persons.append(n)
-        event.description = (
-            "A baby was born to {}".format(
-                n.get_full_title()
-            )
-        )
-        return event
-
-    def gen_event_n_bastard(self, data):
-        event = Event(data)
-        _, n = family.random_noble(self.nobility)
-        event.affected_persons.append(n)
-        event.description = (
-            "A bastard was born to {}".format(
-                n.get_full_title()
-            )
-        )
-        return event
-
-    def gen_event_n_murdered_commoner(self, data):
-        event = Event(data)
-        _, n = family.random_noble(self.nobility)
-        event.affected_persons.append(n)
-        event.description = (
-            "{} was strongly suspected in the murder of a commoner".format(
-                n.get_full_title()
-            )
-        )
-        return event
-
-    def gen_event_n_tournament_win(self, data):
-        event = Event(data)
-        _, n = family.random_noble(self.nobility)
-        event.affected_persons.append(n)
-        event.description = (
-            "{} won a regional tournament".format(
-                n.get_full_title()
-            )
-        )
-        return event
-
-    def gen_event_n_joined_faction(self, data):
-        event = Event(data)
-        _, n = family.random_noble(self.nobility)
-        f = random.choice(self.factions)
-        event.affected_persons.append(n)
-        event.description = (
-            "{} abdicated and joined the {}".format(
-                n.get_full_title(),
-                f.name
-            )
-        )
-        return event
-
-    def gen_event_n_celebrated_birthday(self, data):
-        event = Event(data)
-        _, n = family.random_noble(self.nobility)
-        event.affected_persons.append(n)
-        event.description = (
-            "{} celebrated a birthday".format(
-                n.get_full_title()
-            )
-        )
-        return event
-
-    def gen_event_n_dismissed_courtiers(self, data):
-        event = Event(data)
-        f, n = family.random_noble(self.nobility)
-        event.affected_persons.append(n)
-        event.description = (
-            "{} dismissed all of the courtiers at the {}".format(
-                n.get_full_title(),
-                f.get_full_name()
-            )
-        )
-        return event
-
-    def gen_event_n_honour_duel(self, data):
-        event = Event(data)
-
-        nobles = family.all_nobles(self.nobility)
-        f1, n1 = random.choice(nobles)
-        f2, n2 = random.choice(nobles)
-
-        while (n1.age < person.ADULT_AGE or n2.age < person.ADULT_AGE or
-                n1.get_full_title() == n2.get_full_title()):
-            f1, n1 = random.choice(nobles)
-            f2, n2 = random.choice(nobles)
-
-        event.affected_persons.append(n1)
-        event.affected_persons.append(n2)
-
-        event.description = (
-            "{} of the {} dueled with {} of the {}; {} won".format(
-                n1.get_full_title(),
-                f1.create_html_a_name(self.nobility),
-                n2.get_full_title(),
-                f2.create_html_a_name(self.nobility),
-                random.choice([n1, n2]).get_first_name()
-            )
-        )
-
-        return event
-
-    def gen_event_n_revenge_killing(self, data):
-        event = Event(data)
-
-        nobles = family.all_nobles(self.nobility)
-        f1, n1 = random.choice(nobles)
-        f2, n2 = random.choice(nobles)
-
-        while (n1.age < person.ADULT_AGE or n2.age < person.ADULT_AGE or
-                n1.get_full_title() == n2.get_full_title()):
-            f1, n1 = random.choice(nobles)
-            f2, n2 = random.choice(nobles)
-
-        event.affected_persons.append(n1)
-        event.affected_persons.append(n2)
-
-        event.description = (
-            "{} of the {} killed {} of the {} in vengeance".format(
-                n1.get_full_title(),
-                f1.create_html_a_name(self.nobility),
-                n2.get_full_title(),
-                f2.create_html_a_name(self.nobility)
-            )
-        )
-
-        return event
-
-    def gen_event_n_death_illness(self, data):
-        event = Event(data)
-        _, n = family.random_noble(self.nobility)
-        event.affected_persons.append(n)
-        event.description = (
-            "{} died due to an illness".format(
-                n.get_full_title()
-            )
-        )
-        return event
-
-    def gen_event_n_death_commoner(self, data):
-        event = Event(data)
-        _, n = family.random_noble(self.nobility)
-        event.affected_persons.append(n)
-        event.description = (
-            "{} was killed by a group of commoners".format(
-                n.get_full_title()
-            )
-        )
-        return event
-
-    def gen_event_f_claim_pressed(self, data):
-        event = Event(data)
-
-        f1 = family.random_family(self.nobility)
-        f2 = family.random_family(self.nobility)
-
-        while f1.name == f2.name:
-            f2 = family.random_family(self.nobility)
-
-        event.affected_organizations.append(f1)
-        event.affected_organizations.append(f2)
-
-        event.description = (
-            "The {} has pressed a claim on the {}".format(
-                f1.create_html_a_name(self.nobility),
-                f2.create_html_a_name(self.nobility)
-            )
-        )
-
-        return event
-
-    def gen_event_f_uprising(self, data):
-        event = Event(data)
-        f = family.random_family(self.nobility)
-        event.affected_organizations.append(f)
-        event.description = (
-            "An uprising of smallfolk has taken hold against the {}".format(
-                f.get_full_name()
-            )
-        )
-        return event
-
-    def gen_event_f_new_knight(self, data):
-        event = Event(data)
-        f = family.random_family(self.nobility)
-        while f.rank == family.PETTY_FAMILY:
+    def get_family_for_event(self, actor_def):
+        suitable = False
+        actor_attempts = MAX_ACTOR_ATTEMPTS
+        actors = {}
+        # add requirement for # courtiers, nobles if not present
+        if 'member_defs' in actor_def.keys():
+            num_c = len(
+                [m for m in actor_def['member_defs'] if m['type'] == 'courtier']
+                )
+            num_c -= 1
+            num_n = len(
+                [m for m in actor_def['member_defs'] if m['type'] == 'noble']
+                )
+            num_n -= 1
+            if not 'req_len_gt' in actor_def.keys():
+                actor_def['req_len_gt'] = { 
+                    'courtiers': num_c, 'persons': num_n 
+                    }
+            elif (not 'courtiers' in actor_def['req_len_gt'].keys() 
+                    or actor_def['req_len_gt']['courtiers'] < num_c):
+                actor_def['req_len_gt']['courtiers'] = num_c
+            elif (not 'persons' in actor_def['req_len_gt'].keys() 
+                    or actor_def['req_len_gt']['persons'] < num_n):
+                actor_def['req_len_gt']['persons'] = num_n
+        # get a family meeting requirements
+        while not suitable and actor_attempts > 0:
+            actor_attempts -= 1
             f = family.random_family(self.nobility)
-        event.affected_organizations.append(f)
-        event.description = (
-            "The {} knighted a new person".format(
-                f.get_full_name()
-            )
-        )
-        return event
+            suitable = self.is_suitable(f, actor_def)
+        if actor_attempts == 0:
+            return None
+        # get family members meeting requirements
+        if 'member_defs' in actor_def.keys():
+            for member_def in actor_def['member_defs']:
+                if member_def['type'] == 'noble':
+                    n = self.get_noble_for_event(member_def, f)
+                    if n is None:
+                        return None
+                    else:
+                        actors.update(n)
+                elif member_def['type'] == 'courtier':
+                    c = self.get_courtier_for_event(member_def, f)
+                    if c is None:
+                        return None
+                    else:
+                        actors.update(c)
+        actors[actor_def['var']] = { 'type': 'family', 'object': f }
+        return actors
 
-    def gen_event_f_rebellion(self, data):
-        event = Event(data)
-        f = family.random_family(self.nobility)
-        while f.rank == family.PETTY_FAMILY or len(f.vassals + f.knights) == 0:
-            f = family.random_family(self.nobility)
-        fv = random.choice(f.vassals + f.knights)
-        event.affected_organizations.append(f)
-        event.affected_organizations.append(fv)
-        event.description = (
-            "The {} has rebelled against the {}".format(
-                fv.create_html_a_name(self.nobility),
-                f.create_html_a_name(self.nobility)
-            )
-        )
-        return event
+    def get_noble_for_event(self, actor_def, fam=None):
+        suitable = False
+        actor_attempts = MAX_ACTOR_ATTEMPTS
+        actors = {}
+        while not suitable and actor_attempts > 0:
+            actor_attempts -= 1
+            if fam is not None:
+                f = fam
+                n = random.choice(f.persons)
+            else:
+                f, n = random.choice(family.all_nobles(self.nobility))
+            suitable = self.is_suitable(n, actor_def)
+        if actor_attempts == 0:
+            return None
+        actors[actor_def['var']] = { 'type': 'noble', 'object': n }
+        if 'family_var' in actor_def.keys():
+            actors[actor_def['family_var']] = { 'type': 'family', 'object': f }
+        return actors
 
-    def gen_event_f_festival(self, data):
-        event = Event(data)
-        h = family.random_family(self.nobility)
-        event.affected_organizations.append(h)
-        event.description = (
-            "The {} hosted a festival in honour of {}s".format(
-                h.get_full_name(),
-                random.choice(data['animals']).lower()
-            )
-        )
-        return event
-
-    def gen_event_f_famine(self, data):
-        event = Event(data)
-        f = family.random_family(self.nobility)
-        event.affected_organizations.append(f)
-        event.description = (
-            "A famine has struck the {}".format(
-                f.get_full_name()
-            )
-        )
-        return event
-
-    def gen_event_f_food_plentiful(self, data):
-        event = Event(data)
-        f = family.random_family(self.nobility)
-        event.affected_organizations.append(f)
-        event.description = (
-            "A fortuitous crop season has graced the {}".format(
-                f.get_full_name()
-            )
-        )
-        return event
-
-    def gen_event_f_drought(self, data):
-        event = Event(data)
-        f = family.random_family(self.nobility)
-        event.affected_organizations.append(f)
-        event.description = (
-            "A drought has struck the {}".format(
-                f.get_full_name()
-            )
-        )
-        return event
-
-    def gen_event_f_water_plentiful(self, data):
-        event = Event(data)
-        f = family.random_family(self.nobility)
-        event.affected_organizations.append(f)
-        event.description = (
-            "Plentiful rains grace the {}".format(
-                f.get_full_name()
-            )
-        )
-        return event
-
-    def gen_event_f_economic_downturn(self, data):
-        event = Event(data)
-        f = family.random_family(self.nobility)
-        event.affected_organizations.append(f)
-        event.description = (
-            "An economic downturn has struck the {}".format(
-                f.get_full_name()
-            )
-        )
-        return event
-
-    def gen_event_f_economic_upturn(self, data):
-        event = Event(data)
-        f = family.random_family(self.nobility)
-        event.affected_organizations.append(f)
-        event.description = (
-            "An economic upturn has graced the {}".format(
-                f.get_full_name()
-            )
-        )
-        return event
-
-    def gen_event_c_implication(self, data):
-        event = Event(data)
-
-        f = family.random_family(self.nobility)
-        while len(f.courtiers) < 2:
-            f = family.random_family(self.nobility)
-
-        c1 = random.choice(f.courtiers)
-        c2 = random.choice(f.courtiers)
-
-        while c1.get_first_name() == c2.get_first_name():
-            c2 = random.choice(f.courtiers)
-
-        event.affected_persons.append(c1)
-        event.affected_persons.append(c2)
-
-        event.description = (
-            "{} ({}) was implicated by {} ({}) "
-            "in a plot to grab power".format(
-                c1.get_first_name(),
-                c1.position,
-                c2.get_first_name(),
-                c2.position
-            )
-        )
-
-        return event
-
-    def gen_event_c_theft(self, data):
-        event = Event(data)
-
-        f = family.random_family(self.nobility)
-        while len(f.courtiers) < 2:
-            f = family.random_family(self.nobility)
-
-        c1 = random.choice(f.courtiers)
-        c2 = random.choice(f.courtiers)
-
-        while c1.get_first_name() == c2.get_first_name():
-            c2 = random.choice(f.courtiers)
-
-        event.affected_persons.append(c1)
-        event.affected_persons.append(c2)
-
-        event.description = (
-            "{} ({}) and {} ({}) were "
-            "caught in a plot to steal crown monies".format(
-                c1.get_first_name(),
-                c1.position,
-                c2.get_first_name(),
-                c2.position
-            )
-        )
-
-        return event
-
-    def gen_event_c_office_swap(self, data):
-        event = Event(data)
-
-        f = family.random_family(self.nobility)
-        while len(f.courtiers) < 2:
-            f = family.random_family(self.nobility)
-
-        c1 = random.choice(f.courtiers)
-        c2 = random.choice(f.courtiers)
-        n = random.choice(f.persons)
-
-        while c1.get_first_name() == c2.get_first_name():
-            c2 = random.choice(f.courtiers)
-
-        event.affected_persons.append(c1)
-        event.affected_persons.append(c2)
-
-        event.description = (
-            "{} ({}) and {} ({}) have swapped offices "
-            "by order of {}".format(
-                c1.get_first_name(),
-                c1.position,
-                c2.get_first_name(),
-                c2.position,
-                n.get_full_title()
-            )
-        )
-
-        return event
-
-    def gen_event_c_offense(self, data):
-        event = Event(data)
-
-        f1, n1 = family.random_noble(self.nobility)
-        f2, n2 = family.random_noble(self.nobility)
-        while (len(f1.courtiers) < 1 or
-                n1.get_full_title() == n2.get_full_title()):
-            f1, n1 = family.random_noble(self.nobility)
-            f2, n2 = family.random_noble(self.nobility)
-
-        c = random.choice(f1.courtiers)
-
-        event.affected_persons.append(n1)
-        event.affected_persons.append(n2)
-        event.affected_persons.append(c)
-
-        event.description = (
-            "{} ({}) has greatly offended {} of the {}, to the great "
-            "consternation of {} of the {}".format(
-                c.get_first_name(),
-                c.position,
-                n2.get_full_title(),
-                f2.create_html_a_name(self.nobility),
-                n1.get_full_title(),
-                f1.create_html_a_name(self.nobility),
-            )
-        )
-
-        return event
-
-    def gen_event_c_spy(self, data):
-        event = Event(data)
-
-        c = family.random_courtier(self.nobility)
-        f, n = family.random_noble(self.nobility)
-
-        event.affected_persons.append(c)
-        event.affected_persons.append(n)
-
-        event.description = (
-            "{} ({}) was revealed to be a spy for {} of the {}".format(
-                c.get_first_name(),
-                c.position,
-                n.get_full_title(),
-                f.create_html_a_name(self.nobility)
-            )
-        )
-
-        return event
-
-    def gen_event_c_duel(self, data):
-        event = Event(data)
-
-        c = family.random_courtier(self.nobility)
-        f, n = family.random_noble(self.nobility)
-
-        event.affected_persons.append(c)
-        event.affected_persons.append(n)
-
-        event.description = (
-            "{} ({}) was killed by {} of the {} in a duel of honour".format(
-                c.get_first_name(),
-                c.position,
-                n.get_full_title(),
-                f.create_html_a_name(self.nobility)
-            )
-        )
-
-        return event
-
-    def gen_event_c_hung(self, data):
-        event = Event(data)
-
-        f = family.random_family(self.nobility)
-        while len(f.courtiers) < 1:
-            f = family.random_family(self.nobility)
-
-        c = random.choice(f.courtiers)
-        n = random.choice(f.persons)
-
-        event.affected_persons.append(c)
-        event.affected_persons.append(n)
-
-        event.description = (
-            "{} ({}) was executed by {}".format(
-                c.get_first_name(),
-                c.position,
-                n.get_full_title()
-            )
-        )
-
-        return event
-
-    def gen_event_c_promotion(self, data):
-        event = Event(data)
-
-        f = family.random_family(self.nobility)
-        while len(f.courtiers) < 1:
-            f = family.random_family(self.nobility)
-
-        c = random.choice(f.courtiers)
-        n = random.choice(f.persons)
-
-        event.affected_persons.append(c)
-        event.affected_persons.append(n)
-
-        event.description = (
-            "{} was promoted to the office of {} by {}".format(
-                c.get_first_name(),
-                c.position,
-                n.get_full_title()
-            )
-        )
-
-        return event
-
-    def gen_event_c_demotion(self, data):
-        event = Event(data)
-
-        f = family.random_family(self.nobility)
-        while len(f.courtiers) < 1:
-            f = family.random_family(self.nobility)
-
-        c = random.choice(f.courtiers)
-        n = random.choice(f.persons)
-
-        event.affected_persons.append(c)
-        event.affected_persons.append(n)
-
-        event.description = (
-            "{} was removed from the office of {} by {}".format(
-                c.get_first_name(),
-                c.position,
-                n.get_full_title()
-            )
-        )
-
-        return event
+    # TODO: fix courtier family thing
+    def get_courtier_for_event(self, actor_def, fam=None):
+        suitable = False
+        actor_attempts = MAX_ACTOR_ATTEMPTS
+        actors = {}
+        while not suitable and actor_attempts > 0:
+            actor_attempts -= 1
+            if fam is not None:
+                c = random.choice(fam.courtiers)
+                f = fam
+            else:
+                c = random.choice(family.all_courtiers(self.nobility))
+            suitable = self.is_suitable(c, actor_def)
+        if actor_attempts == 0:
+            return None
+        actors[actor_def['var']] = { 'type': 'courtier', 'object': c }
+        if 'position_var' in actor_def.keys():
+            actors[actor_def['position_var']] = { 'type': 'c_position', 'position': c.position }
+        if 'family_var' in actor_def.keys():
+            actors[actor_def['family_var']] = { 'type': 'family', 'object': f }
+        return actors
 
 
 class Event():

--- a/realm_generator/event.py
+++ b/realm_generator/event.py
@@ -271,7 +271,6 @@ class EventGenerator():
             actors[actor_def['family_var']] = { 'type': 'family', 'object': f }
         return actors
 
-    # TODO: fix courtier family thing
     def get_courtier_for_event(self, actor_def, fam=None):
         suitable = False
         actor_attempts = MAX_ACTOR_ATTEMPTS
@@ -279,8 +278,17 @@ class EventGenerator():
         while not suitable and actor_attempts > 0:
             actor_attempts -= 1
             if fam is not None:
-                c = random.choice(fam.courtiers)
                 f = fam
+                c = random.choice(fam.courtiers)
+            elif 'family_var' in actor_def.keys():
+                f = random.choice(self.all_families)
+                timeout = 1000
+                while len(f.courtiers < 1):
+                    timeout -= 1
+                    if timeout == 0:
+                        return None
+                    f = random.choice(self.all_families)
+                c = random.choice(f.courtiers)
             else:
                 c = random.choice(self.all_courtiers)
             suitable = self.is_suitable(c, actor_def)

--- a/realm_generator/schema/dataset.json
+++ b/realm_generator/schema/dataset.json
@@ -62,6 +62,190 @@
                 "monarchess", "heir", "heiress", "lord", "lordess", 
                 "knight", "knightess"]
         },
+        "actor_noble" : {
+            "$id" : "#actor_noble",
+            "type" : "object",
+            "properties" : {
+                "type" : { "type" : "string", "enum" : [ "noble" ] },
+                "var" : { "type" : "string" },
+                "family_var" : { "type" : "string" },
+                "req_eq" : { "type" : "object" },
+                "req_not_eq" : { "type" : "object" },
+                "req_gt" : { "type" : "object" },
+                "req_lt" : { "type" : "object" },
+                "req_in" : { 
+                    "type" : "object",
+                    "additionalProperties": { "type" : "array" }
+                },
+                "req_not_in" : { 
+                    "type" : "object",
+                    "additionalProperties": { "type" : "array" }
+                },
+                "req_has" : { "type" : "array" },
+                "req_not_has" : { "type" : "array" },
+                "req_len_gt" : { "type" : "object" },
+                "req_len_lt" : { "type" : "object" }
+            },
+            "required" : [ "type", "var" ],
+            "additionalProperties": false
+        },
+        "actor_courtier" : {
+            "$id" : "#actor_courtier",
+            "type" : "object",
+            "properties" : {
+                "type" : { "type" : "string", "enum" : [ "courtier" ] },
+                "var" : { "type" : "string" },
+                "family_var" : { "type" : "string" },
+                "position_var" : { "type" : "string" },
+                "req_eq" : { "type" : "object" },
+                "req_not_eq" : { "type" : "object" },
+                "req_gt" : { "type" : "object" },
+                "req_lt" : { "type" : "object" },
+                "req_in" : { 
+                    "type" : "object",
+                    "additionalProperties": { "type" : "array" }
+                },
+                "req_not_in" : { 
+                    "type" : "object",
+                    "additionalProperties": { "type" : "array" }
+                },
+                "req_has" : { "type" : "array" },
+                "req_not_has" : { "type" : "array" },
+                "req_len_gt" : { "type" : "object" },
+                "req_len_lt" : { "type" : "object" }
+            },
+            "required" : [ "type", "var" ],
+            "additionalProperties": false
+        },
+        "actor_family" : {
+            "$id" : "#actor_family",
+            "type" : "object",
+            "properties" : {
+                "type" : { "type" : "string", "enum" : [ "family" ] },
+                "var" : { "type" : "string" },
+                "member_defs" : {
+                    "type" : "array",
+                    "uniqueItems" : true,
+                    "items" : {
+                        "anyOf" : [
+                            { "$ref" : "#/definitions/actor_noble" },
+                            { "$ref" : "#/definitions/actor_courtier" }
+                        ]
+                    },
+                    "minItems" : 1
+                },
+                "req_eq" : { "type" : "object" },
+                "req_not_eq" : { "type" : "object" },
+                "req_gt" : { "type" : "object" },
+                "req_lt" : { "type" : "object" },
+                "req_in" : { 
+                    "type" : "object",
+                    "additionalProperties": { "type" : "array" }
+                },
+                "req_not_in" : { 
+                    "type" : "object",
+                    "additionalProperties": { "type" : "array" }
+                },
+                "req_has" : { "type" : "array", "minItems" : 1 },
+                "req_not_has" : { "type" : "array", "minItems" : 1 },
+                "req_len_gt" : { "type" : "object" },
+                "req_len_lt" : { "type" : "object" }
+            },
+            "required" : [ "type", "var" ],
+            "additionalProperties": false
+        },
+        "event" : {
+            "$id" : "#event",
+            "type" : "object",
+            "properties" : {
+                "type" : { "type" : "string", "enum" : [ "event" ] },
+                "group_name" : { "type" : "string" },
+                "event_type" : { 
+                    "type" : "string", 
+                    "enum" : [ "family", "noble", "courtier" ] 
+                },
+                "id" : { "type" : "string" },
+                "weight" : { "type" : "number" },
+                "actor_defs" : { 
+                    "type" : "array",
+                    "uniqueItems" : true,
+                    "items" : {
+                        "anyOf" : [
+                            { "$ref" : "#/definitions/actor_family" },
+                            { "$ref" : "#/definitions/actor_noble" },
+                            { "$ref" : "#/definitions/actor_courtier" }
+                        ]
+                    },
+                    "minItems" : 1
+                },
+                "req_matches" : { 
+                    "type" : "array",
+                    "uniqueItems": true,
+                    "items" : {
+                        "type" : "object",
+                        "properties" : {
+                            "actors" : { 
+                                "type" : "array",
+                                "uniqueItems": true, 
+                                "items" : { "type" : "string" },
+                                "minItems" : 2
+                            },
+                            "req_actors_any_eq" : { 
+                                "type" : "array",
+                                "uniqueItems": true,
+                                "items" : { "type" : "string" },
+                                "minItems" : 1
+                            },
+                            "req_actors_any_neq" : { 
+                                "type" : "array",
+                                "uniqueItems": true,
+                                "items" : { "type" : "string" },
+                                "minItems" : 1
+                            },
+                            "req_actors_all_eq" : { 
+                                "type" : "array",
+                                "uniqueItems": true,
+                                "items" : { "type" : "string" },
+                                "minItems" : 1
+                            },
+                            "req_actors_all_neq" : { 
+                                "type" : "array",
+                                "uniqueItems": true,
+                                "items" : { "type" : "string" },
+                                "minItems" : 1
+                            },
+                            "req_vassalage" : { 
+                                "type" : "object",
+                                "properties" : {
+                                    "lord" : { "type" : "string" },
+                                    "vassal" : { "type" : "string" }
+                                },
+                                "required" : [ "lord", "vassal" ],
+                                "additionalProperties" : false
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required" : [ "actors" ]
+                    }
+                },
+                "attach_event" : { 
+                    "type" : "array",
+                    "items" : { "type" : "string" },
+                    "minItems" : 1
+                },
+                "random_tokens" : { 
+                    "type" : "object",
+                     "additionalProperties": { 
+                         "type" : "array",
+                         "items" : { "type" : "string" } 
+                        }
+                },
+                "description" : { "type" : "string" }
+            },
+            "required" : [ "type", "group_name", "event_type", "id", 
+                "weight", "actor_defs", "attach_event", 
+                "description"]
+        },
         "listdata" : {
             "$id" : "#listdata",
             "type" : "object",
@@ -114,7 +298,8 @@
                     { "$ref" : "#/definitions/listdata" },
                     { "$ref" : "#/definitions/alignment" },
                     { "$ref" : "#/definitions/realms"},
-                    { "$ref" : "#/definitions/titles"}
+                    { "$ref" : "#/definitions/titles"},
+                    { "$ref" : "#/definitions/event" }
                 ]
             }
         }

--- a/realm_generator/word/base-events.json
+++ b/realm_generator/word/base-events.json
@@ -323,8 +323,8 @@
             "type" : "event",
             "group_name" : "Default",
             "event_type" : "noble",
-            "id" : "honour_duel_n1_win",
-            "weight" : 500,
+            "id" : "honour_duel",
+            "weight" : 1000,
             "actor_defs" : [
                 {
                     "type" : "noble",
@@ -351,41 +351,8 @@
                 }
             ],
             "attach_event" : [ "n1", "n2" ],
-            "description" : "|n1| of the |f1| dueled with |n2| of the |f2|; |n1| won"
-        },
-        {
-            "type" : "event",
-            "group_name" : "Default",
-            "event_type" : "noble",
-            "id" : "honour_duel_n2_win",
-            "weight" : 500,
-            "actor_defs" : [
-                {
-                    "type" : "noble",
-                    "req_gt" : { "age" : 17 },
-                    "var" : "n1",
-                    "family_var" : "f1"
-                },
-                {
-                    "type" : "noble",
-                    "req_gt" : { "age" : 17 },
-                    "var" : "n2",
-                    "family_var" : "f2"
-                }
-            ],
-            "req_matches" : [
-                {
-                    "actors" : [ "n1", "n2" ],
-                    "req_actors_any_neq" : [ 
-                        "pre_nickname", 
-                        "firstname", 
-                        "post_nickname", 
-                        "family_name" 
-                    ]
-                }
-            ],
-            "attach_event" : [ "n1", "n2" ],
-            "description" : "|n1| of the |f1| dueled with |n2| of the |f2|; |n2| won"
+            "random_tokens" : { "winner" : [ "n1", "n2" ] },
+            "description" : "|n1| of the |f1| dueled with |n2| of the |f2|; |winner| won"
         },
         {
             "type" : "event",

--- a/realm_generator/word/base-events.json
+++ b/realm_generator/word/base-events.json
@@ -1,4 +1,5 @@
 {
+    "$schema" : "../schema/dataset.json",
     "dataset" : "base",
     "data" : [
         {

--- a/realm_generator/word/base-events.json
+++ b/realm_generator/word/base-events.json
@@ -1,0 +1,787 @@
+{
+    "dataset" : "base",
+    "data" : [
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "matrimony_straight",
+            "weight" : 900,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n1",
+                    "family_var" : "f1"
+                },
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n2",
+                    "family_var" : "f2"
+                }
+            ],
+            "req_matches" : [
+                {
+                    "actors" : [ "n1", "n2" ],
+                    "req_actors_any_neq" : [ 
+                        "pre_nickname", 
+                        "firstname", 
+                        "post_nickname", 
+                        "family_name" 
+                    ],
+                    "req_actors_all_neq" : [ "sex" ]
+                }
+            ],
+            "attach_event" : [ "n1", "n2", "f1", "f2" ],
+            "description" : "|n1| of the |f1| was wed to |n2| of the |f2|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "matrimony_gay",
+            "weight" : 100,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n1",
+                    "family_var" : "f1"
+                },
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n2",
+                    "family_var" : "f2"
+                }
+            ],
+            "req_matches" : [
+                {
+                    "actors" : [ "n1", "n2" ],
+                    "req_actors_any_neq" : [ 
+                        "pre_nickname", 
+                        "firstname", 
+                        "post_nickname", 
+                        "family_name" 
+                    ],
+                    "req_actors_all_eq" : [ "sex" ]
+                }
+            ],
+            "attach_event" : [ "n1", "n2", "f1", "f2" ],
+            "description" : "|n1| of the |f1| was wed to |n2| of the |f2|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "divorce_straight",
+            "weight" : 965,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n1",
+                    "family_var" : "f1"
+                },
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n2",
+                    "family_var" : "f2"
+                }
+            ],
+            "req_matches" : [
+                {
+                    "actors" : [ "n1", "n2" ],
+                    "req_actors_any_neq" : [ 
+                        "pre_nickname", 
+                        "firstname", 
+                        "post_nickname", 
+                        "family_name" 
+                    ],
+                    "req_actors_all_neq" : [ "sex" ]
+                }
+            ],
+            "attach_event" : [ "n1", "n2", "f1", "f2" ],
+            "description" : "|n1| of the |f1| and |n2| of the |f2| officially divorced"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "divorce_gay",
+            "weight" : 35,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n1",
+                    "family_var" : "f1"
+                },
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n2",
+                    "family_var" : "f2"
+                }
+            ],
+            "req_matches" : [
+                {
+                    "actors" : [ "n1", "n2" ],
+                    "req_actors_any_neq" : [ 
+                        "pre_nickname", 
+                        "firstname", 
+                        "post_nickname", 
+                        "family_name" 
+                    ],
+                    "req_actors_all_eq" : [ "sex" ]
+                }
+            ],
+            "attach_event" : [ "n1", "n2", "f1", "f2" ],
+            "description" : "|n1| of the |f1| and |n2| of the |f2| officially divorced"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "illicit_lovers_straight",
+            "weight" : 965,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n1",
+                    "family_var" : "f1"
+                },
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n2",
+                    "family_var" : "f2"
+                }
+            ],
+            "req_matches" : [
+                {
+                    "actors" : [ "n1", "n2" ],
+                    "req_actors_any_neq" : [ 
+                        "pre_nickname", 
+                        "firstname", 
+                        "post_nickname", 
+                        "family_name" 
+                    ],
+                    "req_actors_all_neq" : [ "sex" ]
+                }
+            ],
+            "attach_event" : [ "n1", "n2", "f1", "f2" ],
+            "description" : "An illicit love affair was discovered between |n1| of the |f1| and |n2| of the |f2|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "illicit_lovers_gay",
+            "weight" : 35,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n1",
+                    "family_var" : "f1"
+                },
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n2",
+                    "family_var" : "f2"
+                }
+            ],
+            "req_matches" : [
+                {
+                    "actors" : [ "n1", "n2" ],
+                    "req_actors_any_neq" : [ 
+                        "pre_nickname", 
+                        "firstname", 
+                        "post_nickname", 
+                        "family_name" 
+                    ],
+                    "req_actors_all_eq" : [ "sex" ]
+                }
+            ],
+            "attach_event" : [ "n1", "n2", "f1", "f2" ],
+            "description" : "An illicit love affair was discovered between |n1| of the |f1| and |n2| of the |f2|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "baby",
+            "weight" : 1000,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 18 },
+                    "var" : "parent"
+                }
+            ],
+            "attach_event" : [ "parent" ],
+            "description" : "A baby was born to |parent|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "bastard",
+            "weight" : 1000,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 18 },
+                    "var" : "n1"
+                }
+            ],
+            "attach_event" : [ "n1" ],
+            "description" : "A bastard was born to |n1|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "murdered_commoner",
+            "weight" : 1000,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "var" : "n1"
+                }
+            ],
+            "attach_event" : [ "n1" ],
+            "description" : "|n1| was strongly suspected of the murder of a commoner"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "tournament_win",
+            "weight" : 1000,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "var" : "n1"
+                }
+            ],
+            "attach_event" : [ "n1" ],
+            "description" : "|n1| won a regional tournament"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "joined_faction",
+            "weight" : 1000,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "var" : "n1"
+                }
+            ],
+            "attach_event" : [ "n1" ],
+            "description" : "|n1| abdicated and joined the |faction|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "celebrated_birthday",
+            "weight" : 1000,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "var" : "n1"
+                }
+            ],
+            "attach_event" : [ "n1" ],
+            "description" : "|n1| celebrated a birthday"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "dismissed_courtiers",
+            "weight" : 1000,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "var" : "n1",
+                    "family_var" : "f1"
+                }
+            ],
+            "attach_event" : [ "n1" ],
+            "description" : "|n1| dismissed all of the courtiers at the |f1|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "honour_duel_n1_win",
+            "weight" : 500,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n1",
+                    "family_var" : "f1"
+                },
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n2",
+                    "family_var" : "f2"
+                }
+            ],
+            "req_matches" : [
+                {
+                    "actors" : [ "n1", "n2" ],
+                    "req_actors_any_neq" : [ 
+                        "pre_nickname", 
+                        "firstname", 
+                        "post_nickname", 
+                        "family_name" 
+                    ]
+                }
+            ],
+            "attach_event" : [ "n1", "n2" ],
+            "description" : "|n1| of the |f1| dueled with |n2| of the |f2|; |n1| won"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "honour_duel_n2_win",
+            "weight" : 500,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n1",
+                    "family_var" : "f1"
+                },
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n2",
+                    "family_var" : "f2"
+                }
+            ],
+            "req_matches" : [
+                {
+                    "actors" : [ "n1", "n2" ],
+                    "req_actors_any_neq" : [ 
+                        "pre_nickname", 
+                        "firstname", 
+                        "post_nickname", 
+                        "family_name" 
+                    ]
+                }
+            ],
+            "attach_event" : [ "n1", "n2" ],
+            "description" : "|n1| of the |f1| dueled with |n2| of the |f2|; |n2| won"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "revenge_killing",
+            "weight" : 1000,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n1",
+                    "family_var" : "f1"
+                },
+                {
+                    "type" : "noble",
+                    "req_gt" : { "age" : 17 },
+                    "var" : "n2",
+                    "family_var" : "f2"
+                }
+            ],
+            "req_matches" : [
+                {
+                    "actors" : [ "n1", "n2" ],
+                    "req_actors_any_neq" : [ 
+                        "pre_nickname", 
+                        "firstname", 
+                        "post_nickname", 
+                        "family_name" 
+                    ]
+                }
+            ],
+            "attach_event" : [ "n1", "n2" ],
+            "description" : "|n1| of the |f1| killed |n2| of the |f2| in vengeance"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "death_illness",
+            "weight" : 1000,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "var" : "n1"
+                }
+            ],
+            "attach_event" : [ "n1" ],
+            "description" : "|n1| died due to an illness"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "noble",
+            "id" : "death_commoner",
+            "weight" : 1000,
+            "actor_defs" : [
+                {
+                    "type" : "noble",
+                    "var" : "n1"
+                }
+            ],
+            "attach_event" : [ "n1" ],
+            "description" : "|n1| was killed by a group of commoners"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "family",
+            "id" : "claim_pressed",
+            "weight" : 1000,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f1" },
+                { "type" : "family", "var" : "f2" }
+            ],
+            "req_matches" : [
+                {
+                    "actors" : [ "f1", "f2" ],
+                    "req_actors_all_neq" : [ "name" ]
+                }
+            ],
+            "attach_event" : [ "f1", "f2" ],
+            "description" : "The |f1| has pressed a claim on the |f2|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "family",
+            "id" : "uprising",
+            "weight" : 1000,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f1" }
+            ],
+            "attach_event" : [ "f1" ],
+            "description" : "An uprising of smallfolk has taken hold against the |f1|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "family",
+            "id" : "new_knight",
+            "weight" : 1000,
+            "actor_defs" : [
+                { 
+                    "type" : "family", 
+                    "var" : "f1",
+                    "req_not_eq" : { "rank" : "petty" }
+                }
+            ],
+            "attach_event" : [ "f1" ],
+            "description" : "The |f1| knighted a new person"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "family",
+            "id" : "rebellion",
+            "weight" : 1000,
+            "actor_defs" : [
+                { 
+                    "type" : "family", 
+                    "var" : "f1",
+                    "req_not_eq" : { "rank" : "petty" },
+                    "req_len_gt" : { "knights" : 0 }
+                },
+                { "type" : "family", "var" : "f2" }
+            ],
+            "req_matches" : [
+                {
+                    "actors" : [ "f1", "f2" ],
+                    "req_actors_all_neq" : [ "name" ],
+                    "req_vassalage" : { "lord" : "f1", "vassal" : "f2" }
+                }
+            ],
+            "attach_event" : [ "f1", "f2" ],
+            "description" : "The |f2| has rebelled against the |f1|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "family",
+            "id" : "festival",
+            "weight" : 1000,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f1" }
+            ],
+            "attach_event" : [ "f1" ],
+            "description" : "The |f1| hosted a festival in honor of |animal|s"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "family",
+            "id" : "famine",
+            "weight" : 1000,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f1" }
+            ],
+            "attach_event" : [ "f1" ],
+            "description" : "A famine has struck the |f1|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "family",
+            "id" : "food_plentiful",
+            "weight" : 1000,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f1" }
+            ],
+            "attach_event" : [ "f1" ],
+            "description" : "A fortuitous crop season has graced the |f1|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "family",
+            "id" : "drought",
+            "weight" : 1000,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f1" }
+            ],
+            "attach_event" : [ "f1" ],
+            "description" : "A drought has struck the |f1|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "family",
+            "id" : "water_plentiful",
+            "weight" : 1000,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f1" }
+            ],
+            "attach_event" : [ "f1" ],
+            "description" : "Plentiful rains grace the |f1|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "family",
+            "id" : "economic_downturn",
+            "weight" : 1000,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f1" }
+            ],
+            "attach_event" : [ "f1" ],
+            "description" : "An economic downturn has struck the |f1|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "family",
+            "id" : "economic_upturn",
+            "weight" : 1000,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f1" }
+            ],
+            "attach_event" : [ "f1" ],
+            "description" : "An economic upturn has graced the |f1|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "courtier",
+            "id" : "implication",
+            "weight" : 1000,
+            "actor_defs" : [
+                { 
+                    "type" : "family", "var" : "f1",
+                    "member_defs" : [
+                        { "type" : "courtier", "var" : "c1", "position_var" : "c1p" },
+                        { "type" : "courtier", "var" : "c2", "position_var" : "c2p" }
+                    ]
+                }
+            ],
+            "req_matches" : [
+                {
+                    "actors" : [ "c1", "c2" ],
+                    "req_actors_any_neq" : [ "pre_nickname", "firstname", "post_nickname" ]
+                }
+            ],
+            "attach_event" : [ "c1", "c2" ],
+            "description" : "|c1| (|c1p|) was implicated by |c2| (|c2p|) in a plot to grab power"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "courtier",
+            "id" : "theft",
+            "weight" : 1000,
+            "actor_defs" : [
+                { 
+                    "type" : "family", "var" : "f1",
+                    "member_defs" : [
+                        { "type" : "courtier", "var" : "c1", "position_var" : "c1p" },
+                        { "type" : "courtier", "var" : "c2", "position_var" : "c2p" }
+                    ]
+                }
+            ],
+            "req_matches" : [
+                {
+                    "actors" : [ "c1", "c2" ],
+                    "req_actors_any_neq" : [ "pre_nickname", "firstname", "post_nickname" ]
+                }
+            ],
+            "attach_event" : [ "c1", "c2" ],
+            "description" : "|c1| (|c1p|) and |c2| (|c2p|) were caught in a plot to steal crown monies"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "courtier",
+            "id" : "office_swap",
+            "weight" : 1000,
+            "actor_defs" : [
+                {
+                    "type" : "family", "var" : "f1",
+                    "req_len_gt" : { "courtiers" : 1, "persons" : 0 },
+                    "member_defs" : [
+                        { "type" : "courtier", "var" : "c1", "position_var" : "c1p" },
+                        { "type" : "courtier", "var" : "c2", "position_var" : "c2p" },
+                        { "type" : "noble", "var" : "n1" }
+                    ]
+                }
+            ],
+            "req_matches" : [
+                {
+                    "actors" : [ "c1", "c2" ],
+                    "req_actors_any_neq" : [ "pre_nickname", "firstname", "post_nickname" ]
+                }
+            ],
+            "attach_event" : [ "c1", "c2" ],
+            "description" : "|c1| (|c1p|) and |c2| (|c2p|) have swapped offices by order of |n1| of |f1|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "courtier",
+            "id" : "offense",
+            "weight" : 1000,
+            "actor_defs" : [
+                { 
+                    "type" : "family", "var" : "f1",
+                    "member_defs": [
+                        { "type" : "courtier", "var" : "c1", "position_var": "c1p" },
+                        { "type" : "noble", "var" : "n1" }
+                    ]
+                },
+                { "type" : "noble", "var" : "n2", "family_var" : "f2" }
+            ],
+            "req_matches" : [
+                {
+                    "actors" : [ "n1", "n2" ],
+                    "req_actors_any_neq" : [ "pre_nickname", "firstname", "post_nickname" ]
+                }
+            ],
+            "attach_event" : [ "c1", "n1", "n2" ],
+            "description" : "|c1| (|c1p|) has greatly offended |n2| of the |f2|, to the great consternation of |n1| of the |f1|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "courtier",
+            "id" : "spy",
+            "weight" : 1000,
+            "actor_defs" : [
+                { "type" : "courtier", "var" : "c1", "position_var": "c1p" },
+                { "type" : "noble", "var" : "n2", "family_var" : "f2" }
+            ],
+            "attach_event" : [ "c1", "n2" ],
+            "description" : "|c1| (|c1p|) was revealed to be a spy for |n2| of the |f2|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "courtier",
+            "id" : "duel",
+            "weight" : 1000,
+            "actor_defs" : [
+                { "type" : "courtier", "var" : "c1", "position_var": "c1p" },
+                { "type" : "noble", "var" : "n2", "family_var" : "f2" }
+            ],
+            "attach_event" : [ "c1", "n2" ],
+            "description" : "|c1| (|c1p|) was killed by |n2| of the |f2| in a duel of honour"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "courtier",
+            "id" : "hung",
+            "weight" : 1000,
+            "actor_defs" : [
+                { 
+                    "type" : "family", "var" : "f1", "member_defs" : [
+                        { "type" : "courtier", "var" : "c1", "position_var": "c1p" },
+                        { "type" : "noble", "var" : "n1" }
+                    ]
+                }
+            ],
+            "attach_event" : [ "c1", "n1" ],
+            "description" : "|c1| (|c1p|) was executed by |n1|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "courtier",
+            "id" : "promotion",
+            "weight" : 1000,
+            "actor_defs" : [
+                {
+                    "type" : "family", "var" : "f1", "member_defs" : [
+                        { "type" : "courtier", "var" : "c1", "position_var" : "c1p" },
+                        { "type" : "noble", "var" : "n1" }
+                    ]
+                }
+            ],
+            "attach_event" : [ "c1", "n1" ],
+            "description" : "|c1| was promoted to the office of |c1p| by |n1|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Default",
+            "event_type" : "courtier",
+            "id" : "demotion",
+            "weight" : 1000,
+            "actor_defs" : [
+                {
+                    "type" : "family", "var" : "f1", "member_defs" : [
+                        { "type" : "courtier", "var" : "c1", "position_var" : "c1p" },
+                        { "type" : "noble", "var" : "n1" }
+                    ]
+                }
+            ],
+            "attach_event" : [ "c1", "n1" ],
+            "description" : "|c1| was removed from the office of |c1p| by |n1|"
+        }
+    ]
+}

--- a/realm_generator/word/events-omens.json
+++ b/realm_generator/word/events-omens.json
@@ -1,0 +1,251 @@
+{
+    "dataset" : "events-omens",
+    "data" : [
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "family",
+            "id" : "comet",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f" }
+            ],
+            "attach_event" : [ "f" ],
+            "description" : "A comet was seen over the |f|'s lands"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "family",
+            "id" : "meteor-shower",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f" }
+            ],
+            "attach_event" : [ "f" ],
+            "random_tokens" : { "time" : [ "a night", "two nights", "three nights", "four nights", "five nights", "a week" ] },
+            "description" : "Stars fell over the |f|'s lands for |time|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "family",
+            "id" : "solar-eclipse",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f" }
+            ],
+            "attach_event" : [ "f" ],
+            "description" : "The sun was swallowed by shadows recently for several minutes over |f|'s lands"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "family",
+            "id" : "aurora",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f" }
+            ],
+            "attach_event" : [ "f" ],
+            "description" : "The sky over the |f|'s lands was recently shrouded in ethereal veils of light at night"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "family",
+            "id" : "unseasonal-weather",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f" }
+            ],
+            "attach_event" : [ "f" ],
+            "description" : "The |f|'s lands have been experiencing extremely unseasonal weather"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "family",
+            "id" : "unseasonal-weather",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f" }
+            ],
+            "attach_event" : [ "f" ],
+            "description" : "The |f|'s lands have been experiencing extremely unseasonal weather"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "family",
+            "id" : "frog-rain",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f" }
+            ],
+            "attach_event" : [ "f" ],
+            "description" : "Rumors have been spreading that recently frogs rained from the sky in the |f|'s lands"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "family",
+            "id" : "two-headed-animal",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f" }
+            ],
+            "attach_event" : [ "f" ],
+            "random_tokens" : { "outcome" : [ "and died shortly thereafter", "and remains alive in their keeping" ] },
+            "description" : "A newborn |animal| with two heads was found on |f|'s lands |outcome|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "family",
+            "id" : "unseasonal-bloom",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f" }
+            ],
+            "attach_event" : [ "f" ],
+            "description" : "The flowers in |f|'s gardens have fully bloomed all at once"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "family",
+            "id" : "flower-death",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "family", "var" : "f" }
+            ],
+            "attach_event" : [ "f" ],
+            "description" : "The flowers in |f|'s gardens have all withered and died"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "noble",
+            "id" : "lightning-struck",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "noble", "var" : "n", "family_var" : "f" }
+            ],
+            "attach_event" : [ "n" ],
+            "random_tokens" : { "outcome" : [ " but remained unscathed", ", which ruined their clothing but left them unharmed", " and gravely wounded", " and killed" ] },
+            "description" : "|n| was struck by lightning|outcome|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "noble",
+            "id" : "blackbirds",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "noble", "var" : "n", "family_var" : "f" }
+            ],
+            "attach_event" : [ "n" ],
+            "random_tokens" : { "behavior" : [ "circling in the sky over", "bringing small objects to", "attempting to attack" ] },
+            "description" : "Flocks of blackbirds have been seen |behavior| |n|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "noble",
+            "id" : "nightmares",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "noble", "var" : "n", "family_var" : "f" }
+            ],
+            "attach_event" : [ "n" ],
+            "description" : "|n| has been plagued by disturbing nightmares"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "noble",
+            "id" : "dreams",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "noble", "var" : "n", "family_var" : "f" }
+            ],
+            "attach_event" : [ "n" ],
+            "description" : "|n| has been heard exclaiming about their remarkably vivid dreams"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "noble",
+            "id" : "candles-flicker",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "noble", "var" : "n", "family_var" : "f" }
+            ],
+            "attach_event" : [ "n" ],
+            "description" : "Candles have been noticed flickering and dimming around |n|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "noble",
+            "id" : "strange-colored-fire",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "noble", "var" : "n", "family_var" : "f" }
+            ],
+            "attach_event" : [ "n" ],
+            "random_tokens" : { "color" : [ "blue", "green", "purple", "white", "pink" ] },
+            "description" : "A fire was seen turning |color| when |n| approached"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "noble",
+            "id" : "broken-glass",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "noble", "var" : "n", "family_var" : "f" }
+            ],
+            "attach_event" : [ "n" ],
+            "description" : "Several glass objects recently shattered for no apparent reason near |n|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "noble",
+            "id" : "beeeeeeees",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "noble", "var" : "n", "family_var" : "f" }
+            ],
+            "attach_event" : [ "n" ],
+            "random_tokens" : { "outcome" : [ "and stung most viciously", "but left unharmed" ] },
+            "description" : "|n| was swarmed by bees |outcome|"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "noble",
+            "id" : "charlottes-web",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "noble", "var" : "n", "family_var" : "f" }
+            ],
+            "attach_event" : [ "n" ],
+            "description" : "A large spiderweb was recently found, unmistakably containing |n|'s initials"
+        },
+        {
+            "type" : "event",
+            "group_name" : "Signs & Omens",
+            "event_type" : "noble",
+            "id" : "curdled-milk",
+            "weight" : 100,
+            "actor_defs" : [
+                { "type" : "noble", "var" : "n", "family_var" : "f" }
+            ],
+            "attach_event" : [ "n" ],
+            "description" : "All of the milk served to |n| in the past week has curdled"
+        }
+    ]
+}

--- a/realm_generator/word/events-omens.json
+++ b/realm_generator/word/events-omens.json
@@ -1,4 +1,5 @@
 {
+    "$schema" : "../schema/dataset.json",
     "dataset" : "events-omens",
     "data" : [
         {

--- a/templates/home.html
+++ b/templates/home.html
@@ -150,6 +150,19 @@
         <span style="color: red;">{{ error }}</span>
         {% endfor %}
       </div>
+      <div class="col-md">
+        <h4><b>What sources events do you want?</b></h4>
+        {% for subfield in form.events %}
+          <tr>
+            <td>{{ subfield }}</td>
+            <td>{{ subfield.label }}</td>
+          </tr>
+          <br>
+        {% endfor %}
+        {% for error in form.events.errors %}
+        <span style="color: red;">{{ error }}</span>
+        {% endfor %}
+      </div>
     </div>
     <div class="row my-4">
       <div class="col-md">


### PR DESCRIPTION
Rewrite of event generator to parse event definitions from JSON files.
See "event-definitions.md" for detail regarding event definition markup and features, examples and explanations included.
Event parser and definitions replicate all existing events, support additional complex events.
Event parser features: weighted random selection of events; event description with variables; actor constraints based on attributes; actor constraints based on attributes matching / not matching other actors; use of faction, animal, adjective lists; definition and use of arbitrary random variables; two-pass processing allows random selection from defined actors 
JSON Schema updated to include event definition data.
Updated home page to allow user to select event sets to use.

Additional event set "Signs & Omens", various low-weight ominous happenings. Unselected by default, to preserve original behavior.

Efficiency improvement to event generation: EventGenerator object caches all_nobles, all_families, all_courtiers after performing lookups one time at initialization; previously performed full recursive traversal of families for each event generated. This should cause no change in behavior as long as the realm's nobility does not change during event generation. If event generation is updated to allow events to update the nobility (other than appending events to people and families), then I would recommend a dirty flag be used to cause the EventGenerator to update its cache after any change. This does require that additional memory be allocated to the EventGenerator object, but provides an approximately 5x improvement in speed of event generation, even with a measured ~2.1x decrease in speed due to changing to an event parsing architecture.
Tested timing with default realm settings, average of 10 runs, timeit default_timer used around event generation code:
Before any changes (commit fb30c2c0d5bdcaacfad56fa59e3edab539c5e3f9): 1.08450559 seconds
After changing to event parser: 2.31943892 seconds
After update to cache data: 0.19145887 seconds

Time can be further reduced by reducing "MAX_ACTOR_ATTEMPTS" and "MAX_GROUP_ATTEMPTS" timeout values in event.py, but this may result in fewer events being generated.

Possible logical bug in 'req_actors_any_eq' check in match_reqs() function in event.py; suspect this may produce false positives in some cases (>2 actors with multiple attributes being checked), but have not tested thoroughly.

Event parser code is not the most readable. Please reject pull request and tell me to fix it if it's too bad for you to stand.